### PR TITLE
-gpu-mem option on ufal slurm

### DIFF
--- a/bin/qsubmit
+++ b/bin/qsubmit
@@ -14,7 +14,6 @@ def run_script(args):
         del args['command']
     if args['gpus'] == 0:
         del args['gpus']
-        del args['gpu_mem']
     args['log_dir'] = args['logdir']
     args['dependencies'] = args['hold']
     del args['logdir']


### PR DESCRIPTION
current cases:

```
#!/bin/bash

source p3/bin/activate

tdir=tdir
mkdir -p $tdir

qsubmit -q gpu-\* "touch $tdir/test1.ok"
qsubmit -q \* "touch $tdir/test2.ok"
qsubmit "touch $tdir/test3.ok"

qsubmit -q gpu-troja -gpus=2 "touch $tdir/test4.ok"


qsubmit -gpus=1 "touch $tdir/test5.ok"

qsubmit -logdir=abc "touch $tdir/test6.ok"



# logdir permission error
qsubmit -logdir=/abc ":" || touch $tdir/test7.ok


qsubmit -q wrong-queue ":" || touch $tdir/test8.ok

```

implemented now:

```

# gpumem options:

# cpu -> no constraints on GPU ram, although option used 
qsubmit -M 20g "touch $tdir/test-gpuram-1.ok"


qsubmit -gpus=1 -M 20g "touch $tdir/test-gpuram-2.ok"
# either g or G, or just a number
qsubmit -gpus=1 -gpu-mem 20G "touch $tdir/test-gpuram-3.ok"
qsubmit -gpus=1 -gpu-mem 1 "touch $tdir/test-gpuram-4.ok"
qsubmit -gpus=1 -gpu-mem 40g "touch $tdir/test-gpuram-5.ok"

# the size is not available, exiting
qsubmit -gpus=1 --gpu-mem 900g ":" || touch $tdir/test-gpuram-4.ok


```

pending:

```

# pending cases:
# wildcars for machines
qsubmit -q tdll[1-3]\* "touch $tdir/test9.ok"

# mimimum number of nodes, etc.
```